### PR TITLE
Allow inlining SVG

### DIFF
--- a/lib/index.mjs
+++ b/lib/index.mjs
@@ -3,9 +3,9 @@
 import { getValue, parse } from 'markdown-code-block-meta';
 import { visit } from 'unist-util-visit';
 
-import { fetchData, isKroki, validate } from './utils.mjs';
+import { fetchData, toDataURL, isKroki, validate } from './utils.mjs';
 
-async function transform({ node, server, headers }) {
+async function transform({ node, server, headers, inline }) {
   const { meta, value, lang } = node;
 
   const object = parse(meta);
@@ -15,7 +15,7 @@ async function transform({ node, server, headers }) {
 
   const t = lang === 'kroki' ? type : lang;
 
-  const url = await fetchData({
+  const data = await fetchData({
     server,
     headers,
     type: t,
@@ -26,20 +26,26 @@ async function transform({ node, server, headers }) {
   delete node.value;
   delete node.meta;
 
-  node.type = 'paragraph';
-  node.children = [
-    {
-      type: 'image',
-      alt: alt || t,
-      url,
-    },
-  ];
+  if (inline) {
+    node.type = 'html';
+    node.value = `<div class='kroki'>${data}</div>`;
+  } else {
+    node.type = 'paragraph';
+    node.children = [
+      {
+        type: 'image',
+        alt: alt || t,
+        url: toDataURL(data),
+      },
+    ];
+  }
 }
 
 export function remarkKroki({
   server = 'http://localhost:8000',
   headers = {},
   alias = [],
+  inline = false
 } = {}) {
   validate({ server, headers, alias });
 
@@ -49,7 +55,7 @@ export function remarkKroki({
     const temp = [];
 
     visit(tree, condition, (node) => {
-      temp.push(transform({ node, server, headers }));
+      temp.push(transform({ node, server, headers, inline }));
     });
 
     for (const action of temp) {

--- a/lib/utils.mjs
+++ b/lib/utils.mjs
@@ -58,8 +58,13 @@ function Fetch({ server, headers = {}, type, value }) {
           : data,
       ),
     )
-    .then((buffer) => buffer.toString('base64'))
-    .then((base64) => base64Url(base64));
+    .then((buffer) => buffer.toString())
+}
+
+export function toDataURL(data) {
+  const buffer = Buffer.from(data)
+  const base64 = buffer.toString('base64');
+  return base64Url(base64);
 }
 
 export const fetchData = pMemoize(Fetch, {


### PR DESCRIPTION
This adds an `inline` parameter, which defaults to `false`. When it is false, the plugin operates as it previously did. When it is true, instead of adding an image with a data URL, it adds a div and inlines the SVG into the document.

This probably still needs a test.